### PR TITLE
Change URL to jira-ci...

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// DefaultConnectHostname is the default connect hostname
-	DefaultConnectHostname = "jira.ci.harness.io"
+	DefaultConnectHostname = "jira-ci.harness.io"
 )
 
 // Args provides plugin execution arguments.


### PR DESCRIPTION
Changed the default connect hostname to jira-ci.harness.io. We deployed it as this for prod.