### PR TITLE
Extract multiple Jira issue keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 A plugin to attach build and deployment details to a Jira issue. For information on how to use the plugin with drone there is a video [here](https://youtu.be/YIKbLeY1-gI)
 
-This plugin was modified to extract multiple issues by changing the extractIssues function and slight changes to the file plugin.go, also was added a new argument AdditionalMessage to serve as an input variable.
-Changed the util_test.go file to suit the modifications.
+This plugin was modified to extract multiple issues by changing the extractIssues function and slight changes to the file plugin.go, also was added a new argument AdditionalMessage to serve as an input variable. The AdditionalMessage variable has the purpose to contain information of other issues.
+
+The util_test.go file was changed to suit the modifications.
 
 ## Building
 
@@ -40,6 +41,7 @@ docker run --rm \
   -e PLUGIN_PIPELINE=drone \
   -e PLUGIN_ENVIRONMENT=production \
   -e PLUGIN_STATE=successful \
+  -e PLUGIN_ADDITIONAL_MESSAGE="DRONE-43 updated the plugin" \
   -w /drone/src \
   -v $(pwd):/drone/src \
   plugins/jira
@@ -56,4 +58,4 @@ docker run --rm \
 - `ENVIRONMENT_NAME` Deployment environment (optional)
 - `LINK` Link to deployment (optional)
 - `STATE` State of the deployment (optional)
-	
+- `ADDITIONAL_MESSAGE` Additional message containing information about other issues (optional)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A plugin to attach build and deployment details to a Jira issue. For information on how to use the plugin with drone there is a video [here](https://youtu.be/YIKbLeY1-gI)
 
+This plugin was modified to extract multiple issues by changing the extractIssues function and slight changes to the file plugin.go, also was added a new argument AdditionalMessage to serve as an input variable.
+
 ## Building
 
 Build the plugin binary:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A plugin to attach build and deployment details to a Jira issue. For information on how to use the plugin with drone there is a video [here](https://youtu.be/YIKbLeY1-gI)
 
 This plugin was modified to extract multiple issues by changing the extractIssues function and slight changes to the file plugin.go, also was added a new argument AdditionalMessage to serve as an input variable.
+Changed the util_test.go file to suit the modifications.
 
 ## Building
 

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -13,16 +13,19 @@ import (
 // helper function to extract the issue number from
 // the commit details, including the commit message,
 // branch and pull request title.
-func extractIssue(args Args) string {
-	return regexp.MustCompile(args.Project + "\\-\\d+").FindString(
-		fmt.Sprintln(
-			args.Commit.Message,
-			args.PullRequest.Title,
-			args.Commit.Source,
-			args.Commit.Target,
-			args.Commit.Branch,
-		),
-	)
+func extractIssues(args Args) []string {
+
+    regex := regexp.MustCompile(args.Project+"-\\d+")
+    matches := regex.FindAllString(fmt.Sprintln(
+		args.AdditionalMessage,
+        args.Commit.Message,
+        args.PullRequest.Title,
+        args.Commit.Source,
+        args.Commit.Target,
+        args.Commit.Branch,
+    	), -1)
+
+    return matches
 }
 
 // helper function determines the pipeline state.

--- a/plugin/util_test.go
+++ b/plugin/util_test.go
@@ -6,42 +6,73 @@ package plugin
 
 import "testing"
 
-func TestExtractIssue(t *testing.T) {
-	tests := []struct {
-		text string
-		want string
-	}{
-		{
-			text: "TEST-1 this is a test",
-			want: "TEST-1",
-		},
-		{
-			text: "suffix [TEST-123]",
-			want: "TEST-123",
-		},
-		{
-			text: "[TEST-123] prefix",
-			want: "TEST-123",
-		},
-		{
-			text: "TEST-123 prefix",
-			want: "TEST-123",
-		},
-		{
-			text: "feature/TEST-123",
-			want: "TEST-123",
-		},
-		{
-			text: "no issue",
-			want: "",
-		},
-	}
-	for _, test := range tests {
-		var args Args
-		args.Commit.Message = test.text
-		args.Project = "TEST"
-		if got, want := extractIssue(args), test.want; got != want {
-			t.Errorf("Got issue number %v, want %v", got, want)
-		}
-	}
+func compareSlices(s1, s2 []string) bool {
+    if len(s2) < 1 || len(s1) < len(s2){
+        return false
+    }
+    
+    for i := 0; i < len(s1); i++ {
+        found := true
+        for j := 0; j < len(s2); j++ {
+            if s1[i+j] != s2[j] {
+                found = false
+                break
+            }
+        }
+        if found {
+            return true
+        }
+    }
+    return false
+}
+
+func TestExtractIssues(t *testing.T) {
+    tests := []struct {
+        text string
+        want []string
+    }{
+        {
+            text: "TEST-1 this is a test",
+            want: []string{"TEST-1"},
+        },
+        {
+            text: "suffix [TEST-123] [TEST-234]",
+            want: []string{"TEST-123", "TEST-234"},
+        },
+        {
+            text: "[TEST-123] prefix [TEST-456]",
+            want: []string{"TEST-123"},
+        },
+        {
+            text: "Multiple issues: TEST-123, TEST-234, TEST-456",
+            want: []string{"TEST-123"},
+        },
+        {
+            text: "feature/TEST-123 [TEST-456] and [TEST-789]",
+            want: []string{"TEST-123"},
+        },
+        {
+            text: "TEST-123 TEST-456 TEST-789",
+            want: []string{"TEST-123"},
+        },
+        {
+            text: "no issue",
+            want: []string{},
+        },
+    }
+
+    t.Errorf("TESTING")
+
+    for _, test := range tests {
+        var args Args
+        args.Commit.Message = test.text
+        args.Project = "TEST"
+        got := extractIssues(args)
+        t.Errorf("TEXT:%v || WANT: %s", got, test.want) 
+        t.Errorf(" %v", compareSlices(got, test.want))
+        if !compareSlices(got, test.want) {
+            t.Errorf("Got issues %v, want %v", got, test.want)
+        }
+    }
+
 }

--- a/plugin/util_test.go
+++ b/plugin/util_test.go
@@ -45,15 +45,15 @@ func TestExtractIssues(t *testing.T) {
         },
         {
             text: "Multiple issues: TEST-123, TEST-234, TEST-456",
-            want: []string{"TEST-123"},
+            want: []string{"TEST-123", "TEST-234", "TEST-456"},
         },
         {
             text: "feature/TEST-123 [TEST-456] and [TEST-789]",
-            want: []string{"TEST-123"},
+            want: []string{"TEST-123", "TEST-456", "TEST-789"},
         },
         {
             text: "TEST-123 TEST-456 TEST-789",
-            want: []string{"TEST-123"},
+            want: []string{"TEST-123", "TEST-789"},
         },
         {
             text: "no issue",


### PR DESCRIPTION
Fixes #17 

This plugin was modified to extract multiple issues by changing the extractIssues function and slight changes to the file plugin.go, also was added a new argument AdditionalMessage to serve as an input variable. The AdditionalMessage variable has the purpose to contain information of other issues.

The util_test.go file was changed to suit the modifications.